### PR TITLE
Removed hard coded home path from script

### DIFF
--- a/update_RA_cores.sh
+++ b/update_RA_cores.sh
@@ -55,7 +55,7 @@ read -e -p "Where is RetroArch installed on your Steam Deck? (internal, sd)?:" L
 
 if [ $LOCATION = 'internal' ]
 then
-        RA_DIRECTORY=/home/deck/.local/share/Steam/steamapps/common/RetroArch/cores
+        RA_DIRECTORY=~/.local/share/Steam/steamapps/common/RetroArch/cores
 elif [ $LOCATION = 'sd' ]
 then
         RA_DIRECTORY=/run/media/mmcblk0p1/steamapps/common/RetroArch/cores


### PR DESCRIPTION
I replaced "/home/deck" with the tilde symbol. This makes it so the script also works on HoloISO and ChimeraOS installations... Or any linux distros for that matter